### PR TITLE
Add locale Address format support 

### DIFF
--- a/src/main/java/io/codearte/jfairy/EnFairyModule.java
+++ b/src/main/java/io/codearte/jfairy/EnFairyModule.java
@@ -3,10 +3,12 @@ package io.codearte.jfairy;
 import io.codearte.jfairy.data.DataMaster;
 import io.codearte.jfairy.producer.VATIdentificationNumberProvider;
 import io.codearte.jfairy.producer.company.locale.en.EnVATIdentificationNumberProvider;
+import io.codearte.jfairy.producer.person.AddressProvider;
 import io.codearte.jfairy.producer.person.NationalIdentificationNumberFactory;
 import io.codearte.jfairy.producer.person.NationalIdentityCardNumberProvider;
 import io.codearte.jfairy.producer.person.PassportNumberProvider;
 import io.codearte.jfairy.producer.person.locale.NoNationalIdentificationNumberFactory;
+import io.codearte.jfairy.producer.person.locale.en.EnAddressProvider;
 import io.codearte.jfairy.producer.person.locale.en.EnPassportNumberProvider;
 import io.codearte.jfairy.producer.person.locale.en.SocialSecurityCardNumberProvider;
 import io.codearte.jfairy.producer.util.CharConverter;
@@ -30,6 +32,7 @@ public class EnFairyModule extends FairyModule {
 		bind(NationalIdentificationNumberFactory.class).to(NoNationalIdentificationNumberFactory.class);
 		bind(NationalIdentityCardNumberProvider.class).to(SocialSecurityCardNumberProvider.class);
 		bind(VATIdentificationNumberProvider.class).to(EnVATIdentificationNumberProvider.class);
+		bind(AddressProvider.class).to(EnAddressProvider.class);
 		bind(PassportNumberProvider.class).to(EnPassportNumberProvider.class);
 		bind(CharConverter.class).to(NonOpCharConverter.class);
 	}

--- a/src/main/java/io/codearte/jfairy/EsFairyModule.java
+++ b/src/main/java/io/codearte/jfairy/EsFairyModule.java
@@ -3,11 +3,13 @@ package io.codearte.jfairy;
 import io.codearte.jfairy.data.DataMaster;
 import io.codearte.jfairy.producer.VATIdentificationNumberProvider;
 import io.codearte.jfairy.producer.company.locale.es.EsVATIdentificationNumberProvider;
+import io.codearte.jfairy.producer.person.AddressProvider;
 import io.codearte.jfairy.producer.person.NationalIdentificationNumberFactory;
 import io.codearte.jfairy.producer.person.NationalIdentityCardNumberProvider;
 import io.codearte.jfairy.producer.person.PassportNumberProvider;
 import io.codearte.jfairy.producer.person.locale.NoNationalIdentificationNumberFactory;
 import io.codearte.jfairy.producer.person.locale.es.DNINumberProvider;
+import io.codearte.jfairy.producer.person.locale.es.EsAddressProvider;
 import io.codearte.jfairy.producer.person.locale.es.EsPassportNumberProvider;
 import io.codearte.jfairy.producer.util.CharConverter;
 import io.codearte.jfairy.producer.util.locale.NonOpCharConverter;
@@ -30,6 +32,7 @@ public class EsFairyModule extends FairyModule {
 		bind(NationalIdentificationNumberFactory.class).to(NoNationalIdentificationNumberFactory.class);
 		bind(NationalIdentityCardNumberProvider.class).to(DNINumberProvider.class);
 		bind(VATIdentificationNumberProvider.class).to(EsVATIdentificationNumberProvider.class);
+		bind(AddressProvider.class).to(EsAddressProvider.class);
 		bind(PassportNumberProvider.class).to(EsPassportNumberProvider.class);
 		bind(CharConverter.class).to(NonOpCharConverter.class);
 	}

--- a/src/main/java/io/codearte/jfairy/PlFairyModule.java
+++ b/src/main/java/io/codearte/jfairy/PlFairyModule.java
@@ -3,10 +3,12 @@ package io.codearte.jfairy;
 import io.codearte.jfairy.data.DataMaster;
 import io.codearte.jfairy.producer.VATIdentificationNumberProvider;
 import io.codearte.jfairy.producer.company.locale.pl.PlVATIdentificationNumberProvider;
+import io.codearte.jfairy.producer.person.AddressProvider;
 import io.codearte.jfairy.producer.person.NationalIdentificationNumberFactory;
 import io.codearte.jfairy.producer.person.NationalIdentityCardNumberProvider;
 import io.codearte.jfairy.producer.person.PassportNumberProvider;
 import io.codearte.jfairy.producer.person.locale.pl.PeselFactory;
+import io.codearte.jfairy.producer.person.locale.pl.PlAddressProvider;
 import io.codearte.jfairy.producer.person.locale.pl.PlIdentityCardNumberProvider;
 import io.codearte.jfairy.producer.person.locale.pl.PlPassportNumberProvider;
 import io.codearte.jfairy.producer.util.CharConverter;
@@ -30,6 +32,7 @@ public class PlFairyModule extends FairyModule {
 		bind(NationalIdentificationNumberFactory.class).to(PeselFactory.class);
 		bind(NationalIdentityCardNumberProvider.class).to(PlIdentityCardNumberProvider.class);
 		bind(VATIdentificationNumberProvider.class).to(PlVATIdentificationNumberProvider.class);
+		bind(AddressProvider.class).to(PlAddressProvider.class);
 		bind(PassportNumberProvider.class).to(PlPassportNumberProvider.class);
 		bind(CharConverter.class).to(PlCharConverter.class);
 	}

--- a/src/main/java/io/codearte/jfairy/SvFairyModule.java
+++ b/src/main/java/io/codearte/jfairy/SvFairyModule.java
@@ -3,10 +3,12 @@ package io.codearte.jfairy;
 import io.codearte.jfairy.data.DataMaster;
 import io.codearte.jfairy.producer.VATIdentificationNumberProvider;
 import io.codearte.jfairy.producer.company.locale.sv.SvVATIdentificationNumberProvider;
+import io.codearte.jfairy.producer.person.AddressProvider;
 import io.codearte.jfairy.producer.person.NationalIdentificationNumberFactory;
 import io.codearte.jfairy.producer.person.NationalIdentityCardNumberProvider;
 import io.codearte.jfairy.producer.person.PassportNumberProvider;
 import io.codearte.jfairy.producer.person.locale.sv.PersonalIdentityNumberFactory;
+import io.codearte.jfairy.producer.person.locale.sv.SvAddressProvider;
 import io.codearte.jfairy.producer.person.locale.sv.SvNationalIdentityCardNumberProvider;
 import io.codearte.jfairy.producer.person.locale.sv.SvPassportNumberProvider;
 import io.codearte.jfairy.producer.util.CharConverter;
@@ -26,6 +28,7 @@ public class SvFairyModule extends FairyModule {
 		bind(NationalIdentificationNumberFactory.class).to(PersonalIdentityNumberFactory.class);
 		bind(NationalIdentityCardNumberProvider.class).to(SvNationalIdentityCardNumberProvider.class);
 		bind(VATIdentificationNumberProvider.class).to(SvVATIdentificationNumberProvider.class);
+		bind(AddressProvider.class).to(SvAddressProvider.class);
 		bind(PassportNumberProvider.class).to(SvPassportNumberProvider.class);
 		bind(CharConverter.class).to(SvCharConverter.class);
 	}

--- a/src/main/java/io/codearte/jfairy/producer/person/AbstractAddressProvider.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/AbstractAddressProvider.java
@@ -1,0 +1,44 @@
+package io.codearte.jfairy.producer.person;
+
+import io.codearte.jfairy.data.DataMaster;
+import io.codearte.jfairy.producer.BaseProducer;
+
+public abstract class AbstractAddressProvider implements AddressProvider {
+
+	private static final String POSTAL_CODE_FORMAT = "postal_code";
+
+	private static final String CITY = "city";
+
+	private static final String STREET = "street";
+
+	protected final BaseProducer baseProducer;
+
+	protected final DataMaster dataMaster;
+
+	public AbstractAddressProvider(DataMaster dataMaster, BaseProducer baseProducer) {
+		this.baseProducer = baseProducer;
+		this.dataMaster = dataMaster;
+	}
+
+	public String getCity() {
+		return dataMaster.getRandomValue(CITY);
+	}
+
+	public String getPostalCode() {
+		String postalCodeFormat = dataMaster.getRandomValue(POSTAL_CODE_FORMAT);
+		return baseProducer.numerify(postalCodeFormat);
+	}
+
+	public String getStreet() {
+		return dataMaster.getRandomValue(STREET);
+	}
+
+	public String getStreetNumber() {
+		return String.valueOf(baseProducer.randomInt(199));
+	}
+
+	public String getApartmentNumber() {
+		return baseProducer.trueOrFalse() ? String.valueOf(baseProducer.randomInt(350)) : "";
+	}
+
+}

--- a/src/main/java/io/codearte/jfairy/producer/person/Address.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/Address.java
@@ -1,47 +1,19 @@
 package io.codearte.jfairy.producer.person;
 
-public class Address {
+public interface Address {
 
-	private final String postalCode;
+	String street();
 
-	private final String city;
+	String streetNumber();
 
-	private final String street;
+	String apartmentNumber();
 
-	private final String streetNumber;
+	String getPostalCode();
 
-	private final String apartmentNumber;
+	String getCity();
 
-	public Address(String postalCode, String city, String street, String streetNumber, String apartmentNumber) {
-		this.postalCode = postalCode;
-		this.city = city;
-		this.street = street;
-		this.streetNumber = streetNumber;
-		this.apartmentNumber = apartmentNumber;
-	}
+	String getAddressLine1();
 
-	public String getPostalCode() {
-		return postalCode;
-	}
+	String getAddressLine2();
 
-	public String getCity() {
-		return city;
-	}
-
-	public String street() {
-		return street;
-	}
-
-	public String streetNumber() {
-		return streetNumber;
-	}
-
-	public String apartmentNumber() {
-		return apartmentNumber;
-	}
-
-	@Override
-	public String toString() {
-		return postalCode + " " + city;
-	}
 }

--- a/src/main/java/io/codearte/jfairy/producer/person/AddressProvider.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/AddressProvider.java
@@ -1,40 +1,8 @@
 package io.codearte.jfairy.producer.person;
 
 import com.google.inject.Provider;
-import io.codearte.jfairy.data.DataMaster;
-import io.codearte.jfairy.producer.BaseProducer;
 
-import javax.inject.Inject;
+public interface AddressProvider extends Provider<Address> {
 
-public class AddressProvider implements Provider<Address> {
-
-	private static final String POSTAL_CODE_FORMAT = "postal_code";
-
-	private static final String CITY = "city";
-
-	private static final String STREET = "street";
-
-	private final BaseProducer baseProducer;
-
-	private final DataMaster dataMaster;
-
-	@Inject
-	public AddressProvider(DataMaster dataMaster, BaseProducer baseProducer) {
-		this.baseProducer = baseProducer;
-		this.dataMaster = dataMaster;
-	}
-
-	@Override
-	public Address get() {
-		String postalCodeFormat = dataMaster.getRandomValue(POSTAL_CODE_FORMAT);
-
-		String city = dataMaster.getRandomValue(CITY);
-		String street = dataMaster.getRandomValue(STREET);
-		String postalCode = baseProducer.numerify(postalCodeFormat);
-		String streetNumber = String.valueOf(baseProducer.randomInt(25));
-		String apartmentNumber = baseProducer.trueOrFalse() ? String.valueOf(baseProducer.randomInt(350)) : "";
-
-		return new Address(postalCode, city, street, streetNumber, apartmentNumber);
-	}
-
+	Address get();
 }

--- a/src/main/java/io/codearte/jfairy/producer/person/Person.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/Person.java
@@ -30,8 +30,8 @@ public class Person {
 	private final String passportNumber;
 
 	public Person(String firstName, String middleName, String lastName, Address address, String email, String username,
-	              String password, Sex sex, String telephoneNumber, DateTime dateOfBirth, Integer age,
-	              String nationalIdentityCardNumber, String nationalIdentificationNumber, String passportNumber, Company company, String companyEmail) {
+				  String password, Sex sex, String telephoneNumber, DateTime dateOfBirth, Integer age,
+				  String nationalIdentityCardNumber, String nationalIdentificationNumber, String passportNumber, Company company, String companyEmail) {
 		this.nationalIdentityCardNumber = nationalIdentityCardNumber;
 		this.address = address;
 		this.firstName = firstName;

--- a/src/main/java/io/codearte/jfairy/producer/person/locale/en/EnAddress.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/locale/en/EnAddress.java
@@ -1,0 +1,61 @@
+package io.codearte.jfairy.producer.person.locale.en;
+
+import io.codearte.jfairy.producer.person.Address;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR;
+
+public class EnAddress implements Address {
+
+	private final String streetNumber;
+
+	private final String street;
+
+	private final String apartmentNumber;
+
+	private final String city;
+
+	private final String postalCode;
+
+	public EnAddress(String streetNumber, String street, String apartmentNumber, String city, String postalCode) {
+		this.streetNumber = streetNumber;
+		this.street = street;
+		this.apartmentNumber = apartmentNumber;
+		this.city = city;
+		this.postalCode = postalCode;
+	}
+
+	public String streetNumber() {
+		return streetNumber;
+	}
+
+	public String street() {
+		return street;
+	}
+
+	public String apartmentNumber() {
+		return apartmentNumber;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public String getPostalCode() {
+		return postalCode;
+	}
+
+	public String getAddressLine1() {
+		return streetNumber + " " + street
+				+ (isNotBlank(apartmentNumber) ? " APT " + apartmentNumber : "");
+	}
+
+	public String getAddressLine2() {
+		return city + " " + postalCode;
+	}
+
+	@Override
+	public String toString() {
+		return getAddressLine1() + LINE_SEPARATOR + getAddressLine2();
+	}
+}

--- a/src/main/java/io/codearte/jfairy/producer/person/locale/en/EnAddressProvider.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/locale/en/EnAddressProvider.java
@@ -1,0 +1,22 @@
+package io.codearte.jfairy.producer.person.locale.en;
+
+import io.codearte.jfairy.data.DataMaster;
+import io.codearte.jfairy.producer.BaseProducer;
+import io.codearte.jfairy.producer.person.AbstractAddressProvider;
+
+import javax.inject.Inject;
+
+public class EnAddressProvider extends AbstractAddressProvider {
+
+	@Inject
+	public EnAddressProvider(DataMaster dataMaster, BaseProducer baseProducer) {
+		super(dataMaster, baseProducer);
+	}
+
+	@Override
+	public EnAddress get() {
+		return new EnAddress(getStreetNumber(), getStreet(), getApartmentNumber(),
+				getCity(), getPostalCode());
+	}
+
+}

--- a/src/main/java/io/codearte/jfairy/producer/person/locale/es/EsAddress.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/locale/es/EsAddress.java
@@ -1,0 +1,64 @@
+
+package io.codearte.jfairy.producer.person.locale.es;
+
+import io.codearte.jfairy.producer.person.Address;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR;
+
+public class EsAddress implements Address {
+
+	private final String street;
+
+	private final String streetNumber;
+
+	private final String apartmentNumber;
+
+	private final String postalCode;
+
+	private final String city;
+
+
+	public EsAddress(String street, String streetNumber, String apartmentNumber, String postalCode, String city) {
+		this.street = street;
+		this.streetNumber = streetNumber;
+		this.apartmentNumber = apartmentNumber;
+		this.postalCode = postalCode;
+		this.city = city;
+	}
+
+	public String street() {
+		return street;
+	}
+
+	public String streetNumber() {
+		return streetNumber;
+	}
+
+	public String apartmentNumber() {
+		return apartmentNumber;
+	}
+
+	public String getPostalCode() {
+		return postalCode;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public String getAddressLine1() {
+		return street + ", " + streetNumber
+				+ (isNotBlank(apartmentNumber) ? " " + apartmentNumber : "");
+	}
+
+	public String getAddressLine2() {
+		return postalCode + " " + city;
+	}
+
+	@Override
+	public String toString() {
+		return getAddressLine1() + LINE_SEPARATOR + getAddressLine2();
+	}
+}
+

--- a/src/main/java/io/codearte/jfairy/producer/person/locale/es/EsAddressProvider.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/locale/es/EsAddressProvider.java
@@ -1,0 +1,22 @@
+package io.codearte.jfairy.producer.person.locale.es;
+
+import io.codearte.jfairy.data.DataMaster;
+import io.codearte.jfairy.producer.BaseProducer;
+import io.codearte.jfairy.producer.person.AbstractAddressProvider;
+
+import javax.inject.Inject;
+
+public class EsAddressProvider extends AbstractAddressProvider {
+
+	@Inject
+	public EsAddressProvider(DataMaster dataMaster, BaseProducer baseProducer) {
+		super(dataMaster, baseProducer);
+	}
+
+	@Override
+	public EsAddress get() {
+		return new EsAddress(getStreet(), getStreetNumber(), getApartmentNumber(),
+				getPostalCode(), getCity());
+	}
+
+}

--- a/src/main/java/io/codearte/jfairy/producer/person/locale/pl/PlAddress.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/locale/pl/PlAddress.java
@@ -1,0 +1,62 @@
+
+package io.codearte.jfairy.producer.person.locale.pl;
+
+import io.codearte.jfairy.producer.person.Address;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR;
+
+public class PlAddress implements Address {
+
+	private final String street;
+
+	private final String streetNumber;
+
+	private final String apartmentNumber;
+
+	private final String postalCode;
+
+	private final String city;
+
+	public PlAddress(String street, String streetNumber, String apartmentNumber, String postalCode, String city) {
+		this.street = street;
+		this.streetNumber = streetNumber;
+		this.apartmentNumber = apartmentNumber;
+		this.postalCode = postalCode;
+		this.city = city;
+	}
+
+	public String street() {
+		return street;
+	}
+
+	public String streetNumber() {
+		return streetNumber;
+	}
+
+	public String apartmentNumber() {
+		return apartmentNumber;
+	}
+
+	public String getPostalCode() {
+		return postalCode;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public String getAddressLine1() {
+		return street + " " + streetNumber
+				+ (isNotBlank(apartmentNumber) ? ", " + apartmentNumber : "");
+	}
+
+	public String getAddressLine2() {
+		return postalCode + " " + city;
+	}
+
+	@Override
+	public String toString() {
+		return getAddressLine1() + LINE_SEPARATOR + getAddressLine2();
+	}
+}

--- a/src/main/java/io/codearte/jfairy/producer/person/locale/pl/PlAddressProvider.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/locale/pl/PlAddressProvider.java
@@ -1,0 +1,22 @@
+package io.codearte.jfairy.producer.person.locale.pl;
+
+import io.codearte.jfairy.data.DataMaster;
+import io.codearte.jfairy.producer.BaseProducer;
+import io.codearte.jfairy.producer.person.AbstractAddressProvider;
+
+import javax.inject.Inject;
+
+public class PlAddressProvider extends AbstractAddressProvider {
+
+	@Inject
+	public PlAddressProvider(DataMaster dataMaster, BaseProducer baseProducer) {
+		super(dataMaster, baseProducer);
+	}
+
+	@Override
+	public PlAddress get() {
+		return new PlAddress(getStreet(), getStreetNumber(), getApartmentNumber(),
+				getPostalCode(), getCity());
+	}
+
+}

--- a/src/main/java/io/codearte/jfairy/producer/person/locale/sv/SvAddress.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/locale/sv/SvAddress.java
@@ -1,0 +1,62 @@
+
+package io.codearte.jfairy.producer.person.locale.sv;
+
+import io.codearte.jfairy.producer.person.Address;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR;
+
+public class SvAddress implements Address {
+
+	private final String street;
+
+	private final String streetNumber;
+
+	private final String apartmentNumber;
+
+	private final String postalCode;
+
+	private final String city;
+
+	public SvAddress(String street, String streetNumber, String apartmentNumber, String postalCode, String city) {
+		this.street = street;
+		this.streetNumber = streetNumber;
+		this.apartmentNumber = apartmentNumber;
+		this.postalCode = postalCode;
+		this.city = city;
+	}
+
+	public String street() {
+		return street;
+	}
+
+	public String streetNumber() {
+		return streetNumber;
+	}
+
+	public String apartmentNumber() {
+		return apartmentNumber;
+	}
+
+	public String getPostalCode() {
+		return postalCode;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public String getAddressLine1() {
+		return street + " " + streetNumber
+				+ (isNotBlank(apartmentNumber) ? " Lgh " + apartmentNumber : "");
+	}
+
+	public String getAddressLine2() {
+		return postalCode + " " + city;
+	}
+
+	@Override
+	public String toString() {
+		return getAddressLine1() + LINE_SEPARATOR + getAddressLine2();
+	}
+}

--- a/src/main/java/io/codearte/jfairy/producer/person/locale/sv/SvAddressProvider.java
+++ b/src/main/java/io/codearte/jfairy/producer/person/locale/sv/SvAddressProvider.java
@@ -1,0 +1,27 @@
+package io.codearte.jfairy.producer.person.locale.sv;
+
+import io.codearte.jfairy.data.DataMaster;
+import io.codearte.jfairy.producer.BaseProducer;
+import io.codearte.jfairy.producer.person.AbstractAddressProvider;
+
+import javax.inject.Inject;
+
+public class SvAddressProvider extends AbstractAddressProvider {
+
+	@Inject
+	public SvAddressProvider(DataMaster dataMaster, BaseProducer baseProducer) {
+		super(dataMaster, baseProducer);
+	}
+
+	@Override
+	public String getApartmentNumber() {
+		return baseProducer.randomInt(20) < 0 ? String.valueOf(baseProducer.randomInt(350)) : "";
+	}
+
+	@Override
+	public SvAddress get() {
+		return new SvAddress(getStreet(), getStreetNumber(), getApartmentNumber(),
+				getPostalCode(), getCity());
+	}
+
+}

--- a/src/test/groovy/io/codearte/jfairy/FairyFrSpec.groovy
+++ b/src/test/groovy/io/codearte/jfairy/FairyFrSpec.groovy
@@ -19,7 +19,7 @@ class FairyFrSpec extends Specification {
         when:
             Person person = fairy.person();
         then:
-            person.address.city == 'Saint-Laurent-du-Maroni'
+            person.address.city == 'Six-Fours-les-Plages'
     }
 
 }

--- a/src/test/groovy/io/codearte/jfairy/producer/person/locale/en/EnAddressSpec.groovy
+++ b/src/test/groovy/io/codearte/jfairy/producer/person/locale/en/EnAddressSpec.groovy
@@ -1,0 +1,60 @@
+package io.codearte.jfairy.producer.person.locale.en
+
+import io.codearte.jfairy.Fairy
+import io.codearte.jfairy.producer.person.Address
+import spock.lang.Specification
+
+import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR
+
+class EnAddressSpec extends Specification {
+
+	private final int SEED = 7
+	def Fairy fairy;
+	def Address address
+
+	def setup() {
+		fairy = Fairy.builder().withRandom(new Random(SEED)).withLocale(Locale.forLanguageTag("EN")).build()
+		address = fairy.person().getAddress()
+	}
+
+	def "should generate random street"() {
+		expect:
+			address.street() == "Ford Street"
+	}
+
+	def "should generate random streetNumber"() {
+		expect:
+			address.streetNumber() == "11"
+	}
+
+    def "should generate random apartmentNumber"() {
+        expect:
+            address.apartmentNumber() == "313"
+    }
+
+	def "should generate random postalCode"() {
+		expect:
+			address.getPostalCode() == "28664"
+	}
+
+	def "should generate random city"() {
+		expect:
+		    address.getCity() == "San Francisco"
+	}
+
+	def "should return addressLine1 in sv locale format"() {
+		expect:
+			address.getAddressLine1() == "11 Ford Street APT 313"
+	}
+
+	def "should return addressLine2 in sv locale format"() {
+		expect:
+			address.getAddressLine2() == "San Francisco 28664"
+	}
+
+	def "should return address in sv locale format"() {
+		expect:
+			address.toString() == "11 Ford Street APT 313" + LINE_SEPARATOR + "San Francisco 28664"
+	}
+
+}

--- a/src/test/groovy/io/codearte/jfairy/producer/person/locale/en/EnAddressSpec.groovy
+++ b/src/test/groovy/io/codearte/jfairy/producer/person/locale/en/EnAddressSpec.groovy
@@ -42,17 +42,17 @@ class EnAddressSpec extends Specification {
 		    address.getCity() == "San Francisco"
 	}
 
-	def "should return addressLine1 in sv locale format"() {
+	def "should return addressLine1 in en locale format"() {
 		expect:
 			address.getAddressLine1() == "11 Ford Street APT 313"
 	}
 
-	def "should return addressLine2 in sv locale format"() {
+	def "should return addressLine2 in en locale format"() {
 		expect:
 			address.getAddressLine2() == "San Francisco 28664"
 	}
 
-	def "should return address in sv locale format"() {
+	def "should return address in en locale format"() {
 		expect:
 			address.toString() == "11 Ford Street APT 313" + LINE_SEPARATOR + "San Francisco 28664"
 	}

--- a/src/test/groovy/io/codearte/jfairy/producer/person/locale/es/EsAddressSpec.groovy
+++ b/src/test/groovy/io/codearte/jfairy/producer/person/locale/es/EsAddressSpec.groovy
@@ -42,17 +42,17 @@ class EsAddressSpec extends Specification {
 			address.getCity() == "Cáceres"
 	}
 
-	def "should return addressLine1 in sv locale format"() {
+	def "should return addressLine1 in es locale format"() {
 		expect:
 			address.getAddressLine1() == "Vieja, 39 327"
 	}
 
-	def "should return addressLine2 in sv locale format"() {
+	def "should return addressLine2 in es locale format"() {
 		expect:
 			address.getAddressLine2() == "33.915 Cáceres"
 	}
 
-	def "should return address in sv locale format"() {
+	def "should return address in es locale format"() {
 		expect:
 			address.toString() == "Vieja, 39 327" + LINE_SEPARATOR + "33.915 Cáceres"
 	}

--- a/src/test/groovy/io/codearte/jfairy/producer/person/locale/es/EsAddressSpec.groovy
+++ b/src/test/groovy/io/codearte/jfairy/producer/person/locale/es/EsAddressSpec.groovy
@@ -1,0 +1,60 @@
+package io.codearte.jfairy.producer.person.locale.es
+
+import io.codearte.jfairy.Fairy
+import io.codearte.jfairy.producer.person.Address
+import spock.lang.Specification
+
+import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR
+
+class EsAddressSpec extends Specification {
+
+	private final int SEED = 7
+	def Fairy fairy;
+	def Address address
+
+	def setup() {
+		fairy = Fairy.builder().withRandom(new Random(SEED)).withLocale(Locale.forLanguageTag("ES")).build()
+		address = fairy.person().getAddress()
+	}
+
+	def "should generate random street"() {
+		expect:
+			address.street() == "Vieja"
+	}
+
+	def "should generate random streetNumber"() {
+		expect:
+			address.streetNumber() == "39"
+	}
+
+	def "should generate random apartmentNumber"() {
+		expect:
+			address.apartmentNumber() == "327"
+	}
+
+	def "should generate random postalCode"() {
+		expect:
+			address.getPostalCode() == "33.915"
+	}
+
+	def "should generate random city"() {
+		expect:
+			address.getCity() == "Cáceres"
+	}
+
+	def "should return addressLine1 in sv locale format"() {
+		expect:
+			address.getAddressLine1() == "Vieja, 39 327"
+	}
+
+	def "should return addressLine2 in sv locale format"() {
+		expect:
+			address.getAddressLine2() == "33.915 Cáceres"
+	}
+
+	def "should return address in sv locale format"() {
+		expect:
+			address.toString() == "Vieja, 39 327" + LINE_SEPARATOR + "33.915 Cáceres"
+	}
+
+}

--- a/src/test/groovy/io/codearte/jfairy/producer/person/locale/pl/PlAddressSpec.groovy
+++ b/src/test/groovy/io/codearte/jfairy/producer/person/locale/pl/PlAddressSpec.groovy
@@ -1,0 +1,60 @@
+package io.codearte.jfairy.producer.person.locale.pl
+
+import io.codearte.jfairy.Fairy
+import io.codearte.jfairy.producer.person.Address
+import spock.lang.Specification
+
+import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR
+
+class PlAddressSpec extends Specification {
+
+	private final int SEED = 7
+	def Fairy fairy;
+	def Address address
+
+	def setup() {
+		fairy = Fairy.builder().withRandom(new Random(SEED)).withLocale(Locale.forLanguageTag("PL")).build()
+		address = fairy.person().getAddress()
+	}
+
+	def "should generate random street"() {
+		expect:
+			address.street() == "Szulborska"
+	}
+
+	def "should generate random streetNumber"() {
+		expect:
+			address.streetNumber() == "11"
+	}
+
+    def "should generate random apartmentNumber"() {
+        expect:
+            address.apartmentNumber() == ""
+    }
+
+	def "should generate random postalCode"() {
+		expect:
+			address.getPostalCode() == "91-528"
+	}
+
+	def "should generate random city"() {
+		expect:
+		    address.getCity() == "Cedzyna"
+	}
+
+	def "should return addressLine1 in sv locale format"() {
+		expect:
+			address.getAddressLine1() == "Szulborska 11"
+	}
+
+	def "should return addressLine2 in sv locale format"() {
+		expect:
+			address.getAddressLine2() == "91-528 Cedzyna"
+	}
+
+	def "should return address in sv locale format"() {
+		expect:
+			address.toString() == "Szulborska 11" + LINE_SEPARATOR + "91-528 Cedzyna"
+	}
+
+}

--- a/src/test/groovy/io/codearte/jfairy/producer/person/locale/pl/PlAddressSpec.groovy
+++ b/src/test/groovy/io/codearte/jfairy/producer/person/locale/pl/PlAddressSpec.groovy
@@ -42,17 +42,17 @@ class PlAddressSpec extends Specification {
 		    address.getCity() == "Cedzyna"
 	}
 
-	def "should return addressLine1 in sv locale format"() {
+	def "should return addressLine1 in pl locale format"() {
 		expect:
 			address.getAddressLine1() == "Szulborska 11"
 	}
 
-	def "should return addressLine2 in sv locale format"() {
+	def "should return addressLine2 in pl locale format"() {
 		expect:
 			address.getAddressLine2() == "91-528 Cedzyna"
 	}
 
-	def "should return address in sv locale format"() {
+	def "should return address in pl locale format"() {
 		expect:
 			address.toString() == "Szulborska 11" + LINE_SEPARATOR + "91-528 Cedzyna"
 	}

--- a/src/test/groovy/io/codearte/jfairy/producer/person/locale/sv/SvAddressSpec.groovy
+++ b/src/test/groovy/io/codearte/jfairy/producer/person/locale/sv/SvAddressSpec.groovy
@@ -1,0 +1,60 @@
+package io.codearte.jfairy.producer.person.locale.sv
+
+import io.codearte.jfairy.Fairy
+import io.codearte.jfairy.producer.person.Address
+import spock.lang.Specification
+
+import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR
+
+class SvAddressSpec extends Specification {
+
+	private final int SEED = 7
+	def Fairy fairy;
+	def Address address
+
+	def setup() {
+		fairy = Fairy.builder().withRandom(new Random(SEED)).withLocale(Locale.forLanguageTag("SV")).build()
+		address = fairy.person().getAddress()
+	}
+
+	def "should generate random street"() {
+		expect:
+			address.street() == "Götgatan"
+	}
+
+	def "should generate random streetNumber"() {
+		expect:
+			address.streetNumber() == "73"
+	}
+
+	def "should generate random apartmentNumber"() {
+		expect:
+			address.apartmentNumber() == ""
+	}
+
+	def "should generate random postalCode"() {
+		expect:
+			address.getPostalCode() == "528 66"
+	}
+
+	def "should generate random city"() {
+		expect:
+			address.getCity() == "Kristianstad"
+	}
+
+	def "should return addressLine1 in sv locale format"() {
+		expect:
+			address.getAddressLine1() == "Götgatan 73"
+	}
+
+	def "should return addressLine2 in sv locale format"() {
+		expect:
+			address.getAddressLine2() == "528 66 Kristianstad"
+	}
+
+	def "should return address in sv locale format"() {
+		expect:
+			address.toString() == "Götgatan 73" + LINE_SEPARATOR + "528 66 Kristianstad"
+	}
+
+}


### PR DESCRIPTION
...in Address toString method and add two new methods getAddressLine1() + getAddressLine2() that gives the address formated according to the locale.

**English**
```
println address.toString()
11 Ford Street APT 313
San Francisco 28664

println address.addressLine1()
52 Stillwell Avenue

println address.addressLine1()
Washington 23519
```

**Polish**
```
println address.toString()
Szulborska 11
91-528 Cedzyna

println address.addressLine1()
Patriotów 37

println address.addressLine1()
51-977 Srem
```

**Swedish**
```
println address.toString()
Götgatan 73
528 66 Kristianstad

println address.addressLine1()
Norra Agnegatan 120

println address.addressLine1()
235 19 Örnsköldsvik
```

**Spanish**
```
println address.toString()
Vieja, 39 327
33.915 Cáceres

println address.addressLine1()
Doctor Esquerdo, 96 278

println address.addressLine1()
86.125 Orense
```